### PR TITLE
Use volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ USER ${USERNAME}
 
 ENV APP_ENV=docker
 
+VOLUME /var/lib/papi/
+
 EXPOSE 5555
 
 ENTRYPOINT [ "python3", "app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.5'
 services:
   peercoind:
     restart: always
@@ -8,12 +8,16 @@ services:
     environment:
       - RPC_USER=papi
       - RPC_PASSWORD=papipass
+    volumes:
+      - peercoind-volume:/home/sunny/.ppcoin
     command:
       -testnet
       -rpcallowip=*
   papi:
     restart: always
     build: .
+    ports:
+      - "5555:5555"
     depends_on:
       - peercoind
     environment:
@@ -26,5 +30,10 @@ services:
       - RPC_USERNAME=papi
       - RPC_PASSWORD=papipass
     volumes:
-      - /usr/src/app/:/var/lib/papi/
+      - papi-volume:/var/lib/papi/
     command: ["./wait-for-it.sh", "peercoind:9904", "--", "python3", "app.py"]
+volumes:
+  papi-volume:
+    driver: local
+  peercoind-volume:
+    driver: local


### PR DESCRIPTION
This will create two volumes, one for the `peercoind` service called `papi_peercoind-volume` and one for the `papi` service called `papi_papi-volume`.

Once you do a `docker-compose up` you can see the volumes by running:

`docker volume ls`

Inspect the contents of the peercoind volume (assuming the service container name is papi_peercoind_1):

`docker run -ti --rm --volumes-from papi_peercoind_1 alpine ls -ltra /data   # /data is picked up from the volume specified in the peercoind image`

Inspect the contents of the papi volume(assuming the service container name is papi_papi_1) 
`docker run -ti --rm --volumes-from papi_papi_1 alpine ls -ltra /data   # /data is picked up from the volume specified in the peercoind image`



