### PR TITLE
support walletnotify only if node is synced

### DIFF
--- a/papi/data.py
+++ b/papi/data.py
@@ -7,7 +7,8 @@ from conf import *
 import sys
 
 ''' Connection attempts counter'''
-node = attempt_connection( Sync() )
+connection = attempt_connection( Sync() )
+node = connection.node
 
 def init_p2thkeys():
 

--- a/papi/main.py
+++ b/papi/main.py
@@ -116,8 +116,8 @@ def alert():
     txid = request.values.get('txid')
     if txid is not None:
         deck = which_deck(txid)
-        if deck is not None and deck['deck_id'] in subscribed:
-            update_state(deck)
+        if (deck is not None) and (deck['deck_id'] in subscribed):
+            update_state(deck['deck_id'])
 
     return jsonify({'walletnotify': bool(txid)})
 

--- a/papi/sync.py
+++ b/papi/sync.py
@@ -81,6 +81,4 @@ def attempt_connection(connection):
             sleep(3)
             continue
             
-    return connection.node
-
-    
+    return connection

--- a/papi/transaction.py
+++ b/papi/transaction.py
@@ -1,0 +1,15 @@
+from requests import post
+from sys import argv
+from data import connection
+
+def wallet_notify(txid):
+    if not connection.synced:
+        pass
+    else:
+        try:
+            post('http://0.0.0.0:5555/alert', data={'txid':txid})
+        except Exception as e:
+            print(e)
+
+if __name__ == '__main__':
+    wallet_notify(argv[1])

--- a/papi/transaction.sh
+++ b/papi/transaction.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -e
-curl -X POST -d "txid=$1" "http://0.0.0.0:5555/alert"


### PR DESCRIPTION
Delete old transaction.sh and replace with transaction.py

Wallet notify must call transaction.py with input argument as the txid.